### PR TITLE
Support logout endpoint

### DIFF
--- a/packages/loopback-gate-keycloak/src/cookie-session-store.ts
+++ b/packages/loopback-gate-keycloak/src/cookie-session-store.ts
@@ -10,7 +10,7 @@ export class CookieSessionStore {
 
     static middleware: Array<RequestHandler> = [cookieSession({
         secret: process.env['COOKIE_SECRET'],
-        name: 'keycloak',
+        name: KEYCLOAK_STORAGE_COOKIE,
         path: '/',
         httpOnly: true,
         secure: false,
@@ -35,9 +35,16 @@ export class CookieSessionStore {
         }
     }
 
+    static unstore(request: Request, response: Response) {
+        response.clearCookie(KEYCLOAK_STORAGE_COOKIE);
+    }
+
     wrap(grant: Keycloak.Grant) {
         if (grant) {
             grant.store = CookieSessionStore.store(grant);
+            // For some reason the Grant type does not list unstore as a property.
+            // @ts-ignore
+            grant.unstore = CookieSessionStore.unstore;
         }
     }
 

--- a/packages/loopback-gate-keycloak/src/keycloak-client.ts
+++ b/packages/loopback-gate-keycloak/src/keycloak-client.ts
@@ -31,7 +31,11 @@ export class KeycloakClient {
     }
 
     middlewares(): Array<RequestHandler> {
-        return this.keycloak.middleware() as unknown as Array<RequestHandler>;
+        // Specifying logout URL allows the application to setup a logout endpoint
+        // which will automatically revoke tokens and send a response to remove cookies.
+        return this.keycloak.middleware({
+            logout: '/logout'
+        }) as unknown as Array<RequestHandler>;
     }
 
     static getUser(request: Keycloak.GrantedRequest, response: Response, next: any) {

--- a/packages/loopback-gate-keycloak/src/keycloak-client.ts
+++ b/packages/loopback-gate-keycloak/src/keycloak-client.ts
@@ -52,21 +52,6 @@ export class KeycloakClient {
             teams: tokenContent.groups // Requires Keycloak server configured to provide groups via Group Membership Mapper
         };
 
-        // const userAttributes = KeycloakClient.settings && KeycloakClient.settings.attributes;
-
-        // if (userAttributes) {
-        //     user.attributes = {};
-        //     for (var i = 0; i < userAttributes.length; i++) {
-
-        //         // Iterate through specified settings and assign to user
-        //         const key = userAttributes[i];
-        //         const value: any = tokenContent[key];
-        //         if (value) {
-        //             user.attributes[key] = value;
-        //         }
-        //     }
-        // }
-
         return next(null, user);
     }
 


### PR DESCRIPTION
This PR does the following:

1. Pass logout config into keycloak middleware.

2. Implement unstore method in CookieSessionStore to remove cookies.

3. Change the name of the cookieSession middleware to match the name used when storing/unstoring
   - I'm not really sure how this was all working before since the cookie was named 'keycloak' but store/get were using name 'keycloak_grant'. The logout functionality didn't start working until I switched to a consistent name.

With these changes, we can define a /logout endpoint in our loopback application that will automatically revoke the tokens in Keycloaks DB and send a response that removes cookies client side.

I also deleted the commented lines in KeycloakClient related to using attributes since we will not be using attributes any time soon.